### PR TITLE
json-schemas: Don't set defauls to user & app metadata

### DIFF
--- a/src/json-schemas/rules-user-profile.json
+++ b/src/json-schemas/rules-user-profile.json
@@ -44,8 +44,7 @@
   ],
   "properties": {
     "app_metadata": {
-      "type": "object",
-      "default": {}
+      "type": "object"
     },
     "blocked": {
       "type": "boolean",
@@ -104,8 +103,7 @@
       "type": "string"
     },
     "user_metadata": {
-      "type": "object",
-      "default": {}
+      "type": "object"
     },
     "username": {
       "type": "string"


### PR DESCRIPTION
Do not set defaults to the user profile object for the user_metadata and
app_metadata properties because Auth0 doesn't set them to empty Object
by default, it leaves them unset.