### PR TITLE
Don't leak unavailable globals from the sandbox to the runtime - closes #3

### DIFF
--- a/test/fixtures/no-leak-globals-rule.js
+++ b/test/fixtures/no-leak-globals-rule.js
@@ -1,0 +1,51 @@
+function (user, context, cb) {
+  var unaccessible = []
+
+  try {
+    unaccessible.push(!(companyName !== undefined))
+  } catch (_) {
+    // It's expected to have an error here because companyName shouldn't be
+    // bound to the global scope
+    unaccessible.push(true)
+  }
+
+  try {
+    unaccessible.push(!(firm !== undefined))
+  } catch (_) {
+    // It's expected to have an error here because companyName shouldn't be
+    // bound to the global scope
+    unaccessible.push(true)
+  }
+
+  try {
+    unaccessible.push(!(__runtime !== undefined))
+  } catch (_) {
+    // It's expected to have an error here because companyName shouldn't be
+    // bound to the global scope
+    unaccessible.push(true)
+  }
+
+  try {
+    unaccessible.push(!(__ruleUser !== undefined))
+  } catch (_) {
+    // It's expected to have an error here because companyName shouldn't be
+    // bound to the global scope
+    unaccessible.push(true)
+  }
+
+  try {
+    unaccessible.push(!(__ruleContext !== undefined))
+  } catch (_) {
+    // It's expected to have an error here because companyName shouldn't be
+    // bound to the global scope
+    unaccessible.push(true)
+  }
+
+  cb(null, {
+    accessible: [
+      !!process, !!Buffer, !!setTimeout, !!setImmediate, !!console, !!clearTimeout
+    ],
+    unaccessible: unaccessible,
+    context
+  })
+}

--- a/test/runtime.spec.js
+++ b/test/runtime.spec.js
@@ -104,7 +104,7 @@ describe('runtime exports a function which', () => {
         expect(r.context).and.to.be.deep.equal(validCtx)
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     )
   })
@@ -122,7 +122,7 @@ describe('runtime exports a function which', () => {
         )
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     )
   })
@@ -139,7 +139,7 @@ describe('runtime exports a function which', () => {
         expect(r).to.have.property('context').and.to.be.deep.equal({ connection })
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     )
   })

--- a/test/sandbox.spec.js
+++ b/test/sandbox.spec.js
@@ -89,7 +89,7 @@ describe('sandbox exports a function which', () => {
         expect(r.user.shouldBeAllTrue).to.be.deep.equal(Array(6).fill(true))
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     )
   })
@@ -101,7 +101,7 @@ describe('sandbox exports a function which', () => {
         expect(r.context).to.have.property('configuration').and.to.be.deep.equal(config)
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     )
   })
@@ -114,7 +114,7 @@ describe('sandbox exports a function which', () => {
         expect(r).to.have.property('context').and.to.be.deep.equal(validCtx)
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     )
   })
@@ -136,7 +136,7 @@ describe('sandbox exports a function which', () => {
         expect(r.user.unaccessible).to.be.deep.equal(Array(5).fill(true))
       },
       (e) => {
-        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+        throw new Error(`Expected promise to be resolved, but got error: ${e.message}`)
       }
     ).then(
       clean,

--- a/test/sandbox.spec.js
+++ b/test/sandbox.spec.js
@@ -9,6 +9,7 @@ chai.use(dirtyChai)
 describe('sandbox exports a function which', () => {
   const echoRulePath = 'test/fixtures/echo-rule.js'
   const globalsAccessRulePath = 'test/fixtures/globals-access-rule.js'
+  const noLeakGlobalsRulePath = 'test/fixtures/no-leak-globals-rule.js'
   const copyConfigToCtxRulePath = 'test/fixtures/copy-config-to-context-rule.js'
   const validUser = {
     blocked: false,
@@ -114,6 +115,34 @@ describe('sandbox exports a function which', () => {
       },
       (e) => {
         throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+      }
+    )
+  })
+
+  it("doesn't leak other globals than the ones in the white list", () => {
+    function clean () {
+      delete global.companyName
+      delete global.firm
+    }
+
+    global.companyName = `Cycloid ${new Date()}`
+    global.firm = () => { return 'Cycloid, your DevOps team!!!' }
+
+    return sandbox(noLeakGlobalsRulePath, validUser, validCtx).then(
+      (r) => {
+        expect(r.user).to.have.property('accessible').and.to.have.length(6)
+        expect(r.user.accessible).to.be.deep.equal(Array(6).fill(true))
+        expect(r.user).to.have.property('unaccessible').and.to.have.length(5)
+        expect(r.user.unaccessible).to.be.deep.equal(Array(5).fill(true))
+      },
+      (e) => {
+        throw new Error(`Expected promise to b resolved, but got error: ${e.message}`)
+      }
+    ).then(
+      clean,
+      (e) => {
+        clean()
+        throw e
       }
     )
   })


### PR DESCRIPTION
This PR avoid to leak any global variable to the runtime which runs the rule and which are available in the sandbox runtime. It only leaks the ones which are available in Auth0 rules runtime.

Without doing so the runtime could cause false positive on running certain rules.

Although this PR changes the behavior, I consider that's a patch, because it was a bug rather than feature, so I will publish the version as a patch, once it's approved.